### PR TITLE
Do not set group of some files to root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ install:
 	install tenshi ${DESTDIR}${bindir}/tenshi
 	if [ ! -f ${DESTDIR}${sysconfdir}/tenshi/tenshi.conf ]; then \
 		mkdir -p ${DESTDIR}${sysconfdir}/tenshi && \
-		install -g root -m 0644 tenshi.conf ${DESTDIR}${sysconfdir}/tenshi/tenshi.conf; \
+		install -m 0644 tenshi.conf ${DESTDIR}${sysconfdir}/tenshi/tenshi.conf; \
 	fi
 	install -d ${DESTDIR}${docdir}
 	install -m 0644 ${DOCS} ${DESTDIR}${docdir}/
 	[ -d ${DESTDIR}${mandir}/man8 ] || \
 		install -d ${DESTDIR}${mandir}/man8
-	install -g root -m 0644 tenshi.8 ${DESTDIR}${mandir}/man8/
-	install -g root -m 755 -d ${DESTDIR}${libdir}
+	install -m 0644 tenshi.8 ${DESTDIR}${mandir}/man8/
+	install -m 755 -d ${DESTDIR}${libdir}


### PR DESCRIPTION
There are a couple of reasons for that:
1. Some operating systems  (such as FreeBSD) do not have 
    group root (the root user is a member of the wheel group instead).
2. It makes packaging and testing out the installation
    as an unprivileged user a bit harder.
3. Those files will most likely get appropriate owner
    and group anyway during installation anyway.