### PR TITLE
Misc tail reload fixes.

### DIFF
--- a/tenshi
+++ b/tenshi
@@ -123,7 +123,7 @@ if ($listen) {
     push @fhs_syslog, $syslog_listen_socket;
 }
 
-$SIG{'CHLD'} = sub { $debug && debug(5,'CHLD') ; if (!scalar(@tail_pids)) { print RED "[ERROR] child(s) died, bailing out\n"; $time_to_die = 1 }  };
+$SIG{'CHLD'} = sub { $debug && debug(5,'CHLD') ; 1 while waitpid(-1, POSIX::WNOHANG) > 0; if (!scalar(@tail_pids)) { print RED "[ERROR] child(s) died, bailing out\n"; $time_to_die = 1 }  };
 
 prepare_process();
 
@@ -236,12 +236,13 @@ while (!$time_to_die) {
 
             # start new tail(s)
             if (!$profile) {
-                debug(24, 'start ' . scalar(@fhs_log) . ' new tail(s)');
+                debug(24, 'start new tail(s)');
 
                 # close pipes of current log files children before stopping associated tails
                 foreach (@fhs_log) {
                     close($_);
                 }
+                @fhs_log = ();
 
                 log_files_tail();
             }


### PR DESCRIPTION
Reloading when changing log files left old tail processes in zombie state:

tenshi      7500    7481  0 May29 ?        00:00:00 [tail] <defunct>

calling waitpid to reap children in sigchild handler cleans these up.

Clear @fhs_log on tail reload to avoid stale file handles in array.

Don't print current number of file handles in debug message as it refers to current count, not count about to be reopened. log_files_tail() prints debug details of new log files opened and tail processes spawned.

It's been quite a while since a release was cut with a fair number of changes committed, perhaps a new release could be made soon?

Thanks...